### PR TITLE
ONIE template - add grub-common and psmisc

### DIFF
--- a/templates/onie/post-install-config.sh.template
+++ b/templates/onie/post-install-config.sh.template
@@ -86,7 +86,7 @@ case $DEBIAN_RELEASE in
 
         # Packages used for secure boot (amd64 hard code is fine as this is Intel only)
         #linux-headers-amd64?
-        SECURE_BOOT=" qemu-utils ovmf gnu-efi libfile-slurp-perl "
+        SECURE_BOOT=" qemu-utils ovmf gnu-efi libfile-slurp-perl grub-common psmisc "
 
         # make sure this is in a container
         if [ -e /.dockerenv ];then
@@ -133,6 +133,7 @@ DEBIAN_FRONTEND=noninteractive \
                gawk \
                git \
                gperf \
+			   gnupg2 \
                help2man \
                libefivar-dev \
                libexpat1 \
@@ -146,9 +147,11 @@ DEBIAN_FRONTEND=noninteractive \
                libssl-dev \
                libtool \
                libtool-bin \
+			   monkeysphere \
                mtools \
                pkg-config \
                openssl \
+			   psmisc \
                python-all-dev \
                rst2pdf \
                rsync \


### PR DESCRIPTION
This commit updates the ONIE build environment to support
Secure Boot and Secure Boot Extended, which adds a password
to ONIE and GRUB, and has GRUB validating the files it loads against provided signatures.

psmisc is used to provide a clean GPG signing environment
by cleaing out any previously running signing services.

Signed-off-by: Alex Doyle <adoyle@nvidia.com>